### PR TITLE
4回目の授業内容

### DIFF
--- a/04/compose.yml
+++ b/04/compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: mirror.gcr.io/mariadb:11.8.1-ubi9-rc
+    container_name: wordpress_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 'password'
+      MYSQL_DATABASE: 'wordpress'
+      MYSQL_USER: 'wordpress_user'
+      MYSQL_PASSWORD: 'password'
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: mirror.gcr.io/wordpress:6.8.1-php8.1-apache
+    container_name: wordpress_app
+    restart: always
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: 'db:3306'
+      WORDPRESS_DB_USER: 'wordpress_user'
+      WORDPRESS_DB_PASSWORD: 'password'
+      WORDPRESS_DB_NAME: 'wordpress'
+    volumes:
+      - wp_data:/var/www/html
+
+volumes:
+  db_data:
+  wp_data:


### PR DESCRIPTION
## なぜやるか
- conpose を使った wordpress の構築の演習
## なにをやったのか
- Wordpressをdocker composeを使った構築
- Wordpressでユーザーを登録して記事を投稿、そして編集
## 動作確認の手順
- 以下のコマンドで起動
```sh
docker compose up -d
```

- 以下にアクセス
```sh
http://localhost:8080
```

- Wordpress で投稿した記事
<img width="1470" alt="スクリーンショット 2025-06-11 17 51 57" src="https://github.com/user-attachments/assets/7395208e-4df8-47e2-91de-8901cd7b6440" />


- Wordpressで投稿した記事の編集画面
<img width="1470" alt="スクリーンショット 2025-06-11 17 34 17" src="https://github.com/user-attachments/assets/787991e6-b91f-4cfc-9780-86179d176973" />

- 以下のコマンドで停止
```sh
docker compose stop
```

- 以下のコマンドで再起動
```sh
docker compose start
```