### PR TITLE
8回目の授業

### DIFF
--- a/06/cluster.yaml
+++ b/06/cluster.yaml
@@ -1,0 +1,10 @@
+# HA 構成の Cluster を作成する
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/07/db-deployment.yaml
+++ b/07/db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.1-ubi9-rc
+        ports:
+        - containerPort: 3306
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: db-data-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc

--- a/07/db-pvc.yaml
+++ b/07/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/07/db-service.yaml
+++ b/07/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/07/kustomization.yaml
+++ b/07/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+- db-deployment.yaml
+- db-pvc.yaml
+- db-service.yaml
+- secret.yaml
+- wp-deployment.yaml
+- wp-pvc.yaml
+- wp-service.yaml

--- a/07/secret.yaml
+++ b/07/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+stringData:
+  MYSQL_ROOT_PASSWORD: 'password'
+  MYSQL_DATABASE: 'wordpress'
+  MYSQL_USER: 'wordpress_user'
+  MYSQL_PASSWORD: 'password'
+  WORDPRESS_DB_HOST: 'db:3306'
+  WORDPRESS_DB_USER: 'wordpress_user'
+  WORDPRESS_DB_PASSWORD: 'password'
+  WORDPRESS_DB_NAME: 'wordpress'

--- a/07/wp-deployment.yaml
+++ b/07/wp-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:6.8.1-php8.1-apache
+        ports:
+        - containerPort: 80
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: wp-data-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/07/wp-pvc.yaml
+++ b/07/wp-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/07/wp-service.yaml
+++ b/07/wp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: ClusterIP
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80

--- a/08/cluster.yaml
+++ b/08/cluster.yaml
@@ -1,0 +1,10 @@
+# HA 構成の Cluster を作成する
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/08/db-deployment.yaml
+++ b/08/db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.1-ubi9-rc
+        ports:
+        - containerPort: 3306
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "372Mi"
+          limits:
+            cpu: "300m"
+            memory: "1280Mi"
+        volumeMounts:
+        - name: db-data-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc

--- a/08/db-pvc.yaml
+++ b/08/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/08/db-service.yaml
+++ b/08/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/08/kustomization.yaml
+++ b/08/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+- db-deployment.yaml
+- db-pvc.yaml
+- db-service.yaml
+- secret.yaml
+- wp-deployment.yaml
+- wp-pvc.yaml
+- wp-service.yaml

--- a/08/secret.yaml
+++ b/08/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+stringData:
+  MYSQL_ROOT_PASSWORD: 'password'
+  MYSQL_DATABASE: 'wordpress'
+  MYSQL_USER: 'wordpress_user'
+  MYSQL_PASSWORD: 'password'
+  WORDPRESS_DB_HOST: 'db:3306'
+  WORDPRESS_DB_USER: 'wordpress_user'
+  WORDPRESS_DB_PASSWORD: 'password'
+  WORDPRESS_DB_NAME: 'wordpress'

--- a/08/wp-deployment.yaml
+++ b/08/wp-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:6.8.1-php8.1-apache
+        ports:
+        - containerPort: 80
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "300m"
+          limits:
+            cpu: "1200m"
+            memory: "1Gi"
+        volumeMounts:
+        - name: wp-data-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/08/wp-pvc.yaml
+++ b/08/wp-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/08/wp-service.yaml
+++ b/08/wp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: ClusterIP
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -14,3 +14,4 @@ packages:
 - name: kubernetes-sigs/kind@v0.29.0
 - name: derailed/k9s@v0.50.6
 - name: kubernetes/kubernetes/kubectl@v1.33.2
+- name: helm/helm@v3.18.4

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -15,3 +15,4 @@ packages:
 - name: derailed/k9s@v0.50.6
 - name: kubernetes/kubernetes/kubectl@v1.33.2
 - name: helm/helm@v3.18.4
+- name: kubernetes-sigs/kustomize@kustomize/v5.7.0

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.381.1 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: kubernetes-sigs/kind@v0.29.0
+- name: derailed/k9s@v0.50.6
+- name: kubernetes/kubernetes/kubectl@v1.33.2


### PR DESCRIPTION
## 何のため
- 授業の課題のため
## 何をやったか
- k8s の deployment に設定した resources の値を変更して、k8s で Pod の負荷を確認した
## 動作確認の手順
```
kind delete cluster
kind create cluster --config cluster.yaml
kustomize build . |kubectl apply -f -

# kind で pod のリソースが確認できるようにするために metrics-server をデプロイ
kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml

# wordpress にアクセスできるように port-fowward する
kubectl port-forward service/wordpress 8080:8080 > /dev/null

# 新しい vscode の terminal のタブで curl を使って負荷を掛ける。
while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done 

# 結果を表示
kubectl top pods
```
<img width="505" height="71" alt="スクリーンショット 2025-07-23 17 17 40" src="https://github.com/user-attachments/assets/4ea0ddc1-9dd7-40b7-938a-0bffa6382e05" />
